### PR TITLE
Update Volkswagen Amarok generations: Add Wikipedia reference and clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,6 @@
 
 This repository contains signal set configurations for the Volkswagen Amarok, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Volkswagen Amarok.
 
-## Generations
-
-The Volkswagen Amarok has gone through three distinct generations since its introduction:
-
-- **First Generation (2010-2022)**: The original Amarok was introduced as Volkswagen's first mid-size pickup truck. It featured a robust chassis, all-wheel drive capabilities, and a range of diesel engines (primarily 2.0L TDI and 3.0L V6 TDI). Known for its car-like handling with pickup utility, the first-generation Amarok offered payloads of up to 1 tonne and was available in single and double cab configurations. It received a significant facelift in 2016, introducing the more powerful V6 engines and updated technology features.
-
-- **Second Generation (2022-present)**: Developed in partnership with Ford, the second-generation Amarok shares its platform with the Ford Ranger but maintains Volkswagen's design language and character. This generation features increased dimensions, improved off-road capabilities, and more sophisticated technology. Engine options include various diesel powertrains ranging from 2.0L four-cylinder to 3.0L V6 units, with some markets also receiving a 2.3L EcoBoost petrol engine. The second generation offers enhanced towing capabilities, advanced driver assistance systems, and a more premium interior compared to its predecessor.
-
 ## Contributing
 
 Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Volkswagen_Amarok"
+
 generations:
   - name: "First Generation"
     start_year: 2010


### PR DESCRIPTION
- Added references section to generations.yaml with Wikipedia article URL
- Removed duplicate Generations section from README.md (generation data now only in YAML)
- Verified two-generation structure matches Wikipedia article (2010-present and 2022-present)
